### PR TITLE
Add feature to save message on Activity of RP Client App

### DIFF
--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/ExampleFidoUafActivity.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/ExampleFidoUafActivity.java
@@ -118,6 +118,9 @@ public class ExampleFidoUafActivity extends Activity {
 			startActivity(new Intent(
 					"org.ebayopensource.fidouafclient.SettingsActivity"));
 		}
+		if (id == R.id.action_save_message) {
+			SaveMessageDialog.show(this, uafMsg);
+		}
 		return super.onOptionsItemSelected(item);
 	}
 

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/MainActivity.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/MainActivity.java
@@ -338,6 +338,9 @@ public class MainActivity extends Activity {
         if (id == R.id.action_discover) {
             info(this.getWindow().getCurrentFocus());
         }
+        if (id == R.id.action_save_message) {
+            SaveMessageDialog.show(this, msg);
+        }
         return super.onOptionsItemSelected(item);
     }
 

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/SaveMessageDialog.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/SaveMessageDialog.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ebayopensource.fidouafclient;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.text.format.DateFormat;
+import android.util.Log;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class SaveMessageDialog {
+	private static final String TAG = SaveMessageDialog.class.getName();
+
+	private static String getFilename(Context context) {
+		CharSequence datetime = DateFormat.format("yyyyMMddHHmmss", System.currentTimeMillis());
+
+		return context.getString(R.string.format_message_filename, datetime);
+	}
+
+	private static void saveMessage(Context context, CharSequence message, CharSequence filename) {
+		File directory = context.getExternalFilesDir(null);
+
+		if (directory == null) {
+			Toast.makeText(context, R.string.external_storage_is_unavailable, Toast.LENGTH_SHORT).show();
+
+			return;
+		}
+
+		File savedFile = new File(directory, filename.toString());
+
+		BufferedWriter writer = null;
+		try {
+			writer = new BufferedWriter(new FileWriter(savedFile));
+			writer.write(message.toString());
+
+			Toast.makeText(context,
+					context.getString(R.string.format_file_is_saved_to, savedFile.getAbsolutePath()),
+					Toast.LENGTH_LONG).show();
+		} catch (IOException e) {
+			Toast.makeText(context, R.string.file_could_not_be_saved, Toast.LENGTH_SHORT).show();
+			Log.w(TAG, context.getString(R.string.file_could_not_be_saved), e);
+		} finally {
+			if (writer != null) {
+				try {
+					writer.close();
+				} catch (IOException e) {
+					Toast.makeText(context, R.string.file_could_not_be_saved, Toast.LENGTH_SHORT).show();
+					Log.w(TAG, context.getString(R.string.file_could_not_be_saved), e);
+				}
+			}
+		}
+	}
+
+	public static void show(final Context context, final TextView messageTextView) {
+		final View dialogView = View.inflate(context, R.layout.dialog_save_message, null);
+		final EditText filenameEditText = (EditText)dialogView.findViewById(R.id.editFilename);
+
+		final AlertDialog dialog = new AlertDialog.Builder(context).setView(dialogView)
+				.setTitle(R.string.enter_message_filename)
+				.setPositiveButton(R.string.save, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						saveMessage(context, messageTextView.getText(), filenameEditText.getText());
+					}
+				})
+				.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						dialog.cancel();
+					}
+				}).create();
+
+		String filename = getFilename(context);
+
+		filenameEditText.setText(filename);
+		filenameEditText.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+				// Nothing to do.
+			}
+
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) {
+				// Nothing to do.
+			}
+
+			@Override
+			public void afterTextChanged(Editable s) {
+				dialog.getButton(DialogInterface.BUTTON_POSITIVE).setEnabled(0 < s.length());
+			}
+		});
+
+		dialog.show();
+	}
+}

--- a/fidouafclient/app/src/main/res/layout/dialog_save_message.xml
+++ b/fidouafclient/app/src/main/res/layout/dialog_save_message.xml
@@ -1,0 +1,14 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:layout_marginBottom="50dp"
+        android:singleLine="true"
+        android:id="@+id/editFilename"/>
+
+</LinearLayout>

--- a/fidouafclient/app/src/main/res/menu/main.xml
+++ b/fidouafclient/app/src/main/res/menu/main.xml
@@ -12,4 +12,10 @@
         android:showAsAction="never"
         android:title="@string/action_discover"/>
 
+    <item
+        android:id="@+id/action_save_message"
+        android:orderInCategory="100"
+        android:showAsAction="never"
+        android:title="@string/action_save_message"/>
+
 </menu>

--- a/fidouafclient/app/src/main/res/values/strings.xml
+++ b/fidouafclient/app/src/main/res/values/strings.xml
@@ -4,10 +4,18 @@
     <string name="app_name">Martin - UAF Test RP App</string>
     <string name="action_settings">Settings</string>
     <string name="action_discover">Discover</string>
+    <string name="action_save_message">Save message</string>
     <string name="hello_world">Welcome to eBay\'s \n Test FIDO UAF Client</string>
     <string name="name">Username:</string>
     <string name="token">Token:</string>
     <string name="action_button_reg">register</string>
     <string name="textWelcome">Welcome</string>
+    <string name="enter_message_filename">Enter filename to save message</string>
+    <string name="format_message_filename">message-%1$s.txt</string>
+    <string name="external_storage_is_unavailable">External storage is unavailable</string>
+    <string name="file_could_not_be_saved">File could not be saved</string>
+    <string name="format_file_is_saved_to">File is saved to %1$s</string>
+    <string name="save">Save</string>
+    <string name="cancel">Cancel</string>
 
 </resources>


### PR DESCRIPTION
A message displayed Activity could be saved to a file on
the primary external storage to debug UAF protocol message.

Tap "Save message" on menu to save the message on the Activity.
And the file is written to
Android/data/org.ebayopensource.fidouafclient/files on the
primary external storage.
