### PR TITLE
Removing AUTHENTICATOR_NONCE from Registration Assertion

### DIFF
--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/RegAssertionBuilder.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/RegAssertionBuilder.java
@@ -157,12 +157,6 @@ public class RegAssertionBuilder {
 		byteout.write(encodeInt(length));
 		byteout.write(value);
 
-		byteout.write(encodeInt(TagsEnum.TAG_AUTHENTICATOR_NONCE.id));
-		value = SHA.sha256(BCrypt.gensalt()).getBytes();
-		length = value.length;
-		byteout.write(encodeInt(length));
-		byteout.write(value);
-
 		return byteout.toByteArray();
 	}
 


### PR DESCRIPTION
Per the Fido Authenticator commands spec (section 6.1.1.1
TAG_UAFV1_REG_ASSERTION) there is no authenticator nonce in a
registration assertion; it is only meant to be present in an
authentication assertion. Removing it from the client code.
