### PR TITLE
fix Auth class to handle AppId/FacetId on FIDO UAF Client.

### DIFF
--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/MainActivity.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/MainActivity.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 import org.ebayopensource.fidouafclient.curl.Curl;
 import org.ebayopensource.fidouafclient.op.Auth;
 import org.ebayopensource.fidouafclient.op.Dereg;
+import org.ebayopensource.fidouafclient.op.OpUtils;
 import org.ebayopensource.fidouafclient.op.Reg;
 import org.ebayopensource.fidouafclient.util.Endpoints;
 import org.ebayopensource.fidouafclient.util.Preferences;
@@ -96,7 +97,7 @@ public class MainActivity extends Activity {
 //		i.setType("application/fido.uaf_asm+json");
 
         Bundle data = new Bundle();
-        data.putString("message", reg.getEmptyUafMsgRegRequest());
+        data.putString("message", OpUtils.getEmptyUafMsgRegRequest());
         data.putString("UAFIntentType", UAFIntentType.DISCOVER.name());
         i.putExtras(data);
 //		i.setComponent(new ComponentName(queryIntentActivities.get(0).activityInfo.packageName, queryIntentActivities.get(0).activityInfo.name));
@@ -175,7 +176,13 @@ public class MainActivity extends Activity {
 
     public void authRequest(View view) {
         title.setText("Authentication operation executed");
-        String authRequest = auth.getUafMsgRequest(false);
+        String facetID = "";
+        try {
+            facetID = getFacetID(this.getPackageManager().getPackageInfo(this.getPackageName(), this.getPackageManager().GET_SIGNATURES));
+        } catch (NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        String authRequest = auth.getUafMsgRequest(facetID,this,false);
         Intent i = new Intent("org.fidoalliance.intent.FIDO_OPERATION");
         i.addCategory("android.intent.category.DEFAULT");
         i.setType("application/fido.uaf_client+json");
@@ -189,7 +196,13 @@ public class MainActivity extends Activity {
 
     public void trxRequest(View view) {
         title.setText("Authentication operation executed");
-        String authRequest = auth.getUafMsgRequest(true);
+        String facetID = "";
+        try {
+            facetID = getFacetID(this.getPackageManager().getPackageInfo(this.getPackageName(), this.getPackageManager().GET_SIGNATURES));
+        } catch (NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        String authRequest = auth.getUafMsgRequest(facetID,this,true);
         Intent i = new Intent("org.fidoalliance.intent.FIDO_OPERATION");
         i.addCategory("android.intent.category.DEFAULT");
         i.setType("application/fido.uaf_client+json");

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/OpUtils.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/OpUtils.java
@@ -1,0 +1,193 @@
+package org.ebayopensource.fidouafclient.op;
+
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
+import android.util.Base64;
+
+import com.google.gson.Gson;
+
+import org.ebayopensource.fido.uaf.msg.TrustedFacets;
+import org.ebayopensource.fido.uaf.msg.TrustedFacetsList;
+import org.ebayopensource.fido.uaf.msg.Version;
+import org.ebayopensource.fidouafclient.curl.Curl;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Utility Class for UaFRequest messages - Registration & Authentication
+ */
+public abstract class OpUtils {
+
+
+    /**
+     * Process Request Message
+     * @param serverResponse Registration or Authentication request message
+     * @param facetId Application facet Id
+     * @param context Android Application Context
+     * @param isTrx always false for Registration messages. For Authentication it should be true only for transactions
+     * @return uafProtocolMessage
+     */
+    public static String getUafRequest(String serverResponse, String facetId, Context context, boolean isTrx){
+        String msg = "{\"uafProtocolMessage\":\"";
+        try {
+            JSONArray requestArray = new JSONArray(serverResponse);
+            String appID = ((JSONObject) requestArray.get(0)).getJSONObject("header").getString("appID");
+            Version version = (new Gson()).fromJson(((JSONObject) requestArray.get(0)).getJSONObject("header").getString("upv"),Version.class);
+            // If the AppID is null or empty, the client MUST set the AppID to be the FacetID of
+            // the caller, and the operation may proceed without additional processing.
+            if (appID == null || appID.isEmpty()) {
+                if (checkAppSignature(facetId, context)) {
+                    ((JSONObject) requestArray.get(0)).getJSONObject("header").put("appID", facetId);
+                }
+            }else {
+                //If the AppID is not an HTTPS URL, and matches the FacetID of the caller, no additional
+                // processing is necessary and the operation may proceed.
+                if (!facetId.equals(appID)) {
+                    // Begin to fetch the Trusted Facet List using the HTTP GET method
+                    String trustedFacetsJson = getTrustedFacets(appID);
+                    TrustedFacetsList trustedFacets = (new Gson()).fromJson(trustedFacetsJson, TrustedFacetsList.class);
+                    // After processing the trustedFacets entry of the correct version and removing
+                    // any invalid entries, if the caller's FacetID matches one listed in ids,
+                    // the operation is allowed.
+                    boolean facetFound = processTrustedFacetsList(trustedFacets,version,facetId);
+                    if ((!facetFound) || (!checkAppSignature(facetId, context))){
+                        return getEmptyUafMsgRegRequest();
+                    }
+                } else {
+                    if (! checkAppSignature(facetId, context)) {
+                        return getEmptyUafMsgRegRequest();
+                    }
+                }
+            }
+            if (isTrx){
+                ((JSONObject) requestArray.get(0)).put("transaction", getTransaction());
+            }
+            JSONObject uafMsg = new JSONObject();
+            uafMsg.put("uafProtocolMessage", requestArray.toString());
+            return uafMsg.toString();
+        } catch (JSONException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        return getEmptyUafMsgRegRequest();
+    }
+
+    public static String getEmptyUafMsgRegRequest (){
+        String msg = "{\"uafProtocolMessage\":";
+        msg = msg + "\"\"";
+        msg = msg + "}";
+        return msg;
+    }
+
+    private static JSONArray getTransaction (){
+        JSONArray ret = new JSONArray();
+        JSONObject trx = new JSONObject();
+
+        try {
+            trx.put("contentType", "text/plain");
+            trx.put("content", Base64.encodeToString("Authentication".getBytes(),Base64.URL_SAFE));
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        ret.put(trx);
+        return ret;
+    }
+
+    /**
+     * From among the objects in the trustedFacet array, select the one with the version matching
+     * that of the protocol message version. The scheme of URLs in ids MUST identify either an
+     * application identity (e.g. using the apk:, ios: or similar scheme) or an https: Web Origin [RFC6454].
+     * Entries in ids using the https:// scheme MUST contain only scheme, host and port components,
+     * with an optional trailing /. Any path, query string, username/password, or fragment information
+     * MUST be discarded.
+     * @param trustedFacetsList
+     * @param version
+     * @param facetId
+     * @return true if appID list contains facetId (current Android application's signature).
+     */
+    private static boolean processTrustedFacetsList(TrustedFacetsList trustedFacetsList, Version version, String facetId){
+        for (TrustedFacets trustedFacets: trustedFacetsList.getTrustedFacets()){
+            // select the one with the version matching that of the protocol message version
+            if ((trustedFacets.getVersion().minor >= version.minor)
+                    && (trustedFacets.getVersion().major <= version.major)) {
+                //The scheme of URLs in ids MUST identify either an application identity
+                // (e.g. using the apk:, ios: or similar scheme) or an https: Web Origin [RFC6454].
+                for (String id : trustedFacets.getIds()) {
+                    if (id.equals(facetId)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A double check about app signature that was passed by MainActivity as facetID.
+     * @param facetId a string value composed by app hash. I.e. android:apk-key-hash:Lir5oIjf552K/XN4bTul0VS3GfM
+     * @param context Application Context
+     * @return true if the signature executed on runtime matches if signature sent by MainActivity
+     */
+    private static boolean checkAppSignature(String facetId, Context context){
+        try {
+            PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_SIGNATURES);
+            for (Signature sign: packageInfo.signatures) {
+                byte[] sB = sign.toByteArray();
+                MessageDigest messageDigest = MessageDigest.getInstance("SHA1");
+                messageDigest.update(sign.toByteArray());
+                String currentSignature = Base64.encodeToString(messageDigest.digest(), Base64.DEFAULT);
+                if (currentSignature.toLowerCase().contains(facetId.split(":")[2].toLowerCase())){
+                    return true;
+                }
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    /**
+     * Fetches the Trusted Facet List using the HTTP GET method. The location MUST be identified with
+     * an HTTPS URL. A Trusted Facet List MAY contain an unlimited number of entries, but clients MAY
+     * truncate or decline to process large responses.
+     * @param appID an identifier for a set of different Facets of a relying party's application.
+     *              The AppID is a URL pointing to the TrustedFacets, i.e. list of FacetIDs related
+     *              to this AppID.
+     * @return  Trusted Facets List
+     */
+    private static String getTrustedFacets(String appID){
+        //TODO The caching related HTTP header fields in the HTTP response (e.g. “Expires”) SHOULD be respected when fetching a Trusted Facets List.
+        return Curl.getInSeparateThread(appID);
+    }
+
+    public static String clientSendRegResponse (String uafMessage, String endpoint){
+        StringBuffer res = new StringBuffer();
+        String decoded = "";
+        try {
+            JSONObject json = new JSONObject (uafMessage);
+            decoded = json.getString("uafProtocolMessage").replace("\\", "");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        res.append("#uafMessageegOut\n"+decoded);
+        String headerStr = "Content-Type:Application/json Accept:Application/json";
+        res.append("\n\n#ServerResponse\n");
+        String serverResponse = Curl.postInSeparateThread(endpoint, headerStr , decoded);
+        res.append(serverResponse);
+        return res.toString();
+    }
+
+
+
+}

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Reg.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Reg.java
@@ -16,9 +16,6 @@
 
 package org.ebayopensource.fidouafclient.op;
 
-import org.ebayopensource.fido.uaf.msg.TrustedFacets;
-import org.ebayopensource.fido.uaf.msg.TrustedFacetsList;
-import org.ebayopensource.fido.uaf.msg.Version;
 import org.ebayopensource.fidouafclient.curl.Curl;
 import org.ebayopensource.fidouafclient.util.Endpoints;
 import org.ebayopensource.fidouafclient.util.Preferences;
@@ -30,144 +27,22 @@ import org.ebayopensource.fido.uaf.msg.RegistrationRequest;
 import org.ebayopensource.fido.uaf.msg.RegistrationResponse;
 import org.ebayopensource.fido.uaf.msg.asm.obj.RegisterIn;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.Signature;
 import android.util.Base64;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class Reg {
 	
 	private Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
 	public String getUafMsgRegRequest (String username, String facetId, Context context){
-		String msg = "{\"uafProtocolMessage\":\"";
-		try {
-			String serverResponse = getRegRequest(username);
-			JSONArray reg = new JSONArray(serverResponse);
-			String appID = ((JSONObject) reg.get(0)).getJSONObject("header").getString("appID");
-			Version version = (new Gson()).fromJson(((JSONObject) reg.get(0)).getJSONObject("header").getString("upv"),Version.class);
-			// If the AppID is null or empty, the client MUST set the AppID to be the FacetID of
-			// the caller, and the operation may proceed without additional processing.
-			if (appID == null || appID.isEmpty()) {
-				if (this.checkAppSignature(facetId, context)) {
-					((JSONObject) reg.get(0)).getJSONObject("header").put("appID", facetId);
-				}
-			}else {
-				//If the AppID is not an HTTPS URL, and matches the FacetID of the caller, no additional
-				// processing is necessary and the operation may proceed.
-				if (!facetId.equals(appID)) {
-					// Begin to fetch the Trusted Facet List using the HTTP GET method
-					String trustedFacetsJson = this.getTrustedFacets(appID);
-					TrustedFacetsList trustedFacets = (new Gson()).fromJson(trustedFacetsJson, TrustedFacetsList.class);
-					// After processing the trustedFacets entry of the correct version and removing
-					// any invalid entries, if the caller's FacetID matches one listed in ids,
-					// the operation is allowed.
-					boolean facetFound = this.processTrustedFacetsList(trustedFacets,version,facetId);
-					if ((!facetFound) || (!this.checkAppSignature(facetId, context))){
-						return msg;
-					}
-				} else {
-					if (! this.checkAppSignature(facetId, context)) {
-						return msg;
-					}
-				}
-			}
-			JSONObject uafMsg = new JSONObject();
-			uafMsg.put("uafProtocolMessage", reg.toString());
-			return uafMsg.toString();
-		} catch (JSONException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return msg;
-	}
-	
-	public String getEmptyUafMsgRegRequest (){
-		String msg = "{\"uafProtocolMessage\":";
-		msg = msg + "\"\"";
-		msg = msg + "}";
-		return msg;
-	}
-
-	/**
-	 * From among the objects in the trustedFacet array, select the one with the version matching
-	 * that of the protocol message version. The scheme of URLs in ids MUST identify either an
-	 * application identity (e.g. using the apk:, ios: or similar scheme) or an https: Web Origin [RFC6454].
-	 * Entries in ids using the https:// scheme MUST contain only scheme, host and port components,
-	 * with an optional trailing /. Any path, query string, username/password, or fragment information
-	 * MUST be discarded.
-	 * @param trustedFacetsList
-	 * @param version
-	 * @param facetId
-     * @return true if appID list contains facetId (current Android application's signature).
-     */
-	public boolean processTrustedFacetsList(TrustedFacetsList trustedFacetsList, Version version, String facetId){
-		for (TrustedFacets trustedFacets: trustedFacetsList.getTrustedFacets()){
-			// select the one with the version matching that of the protocol message version
-			if ((trustedFacets.getVersion().minor >= version.minor)
-					&& (trustedFacets.getVersion().major <= version.major)) {
-				//The scheme of URLs in ids MUST identify either an application identity
-				// (e.g. using the apk:, ios: or similar scheme) or an https: Web Origin [RFC6454].
-				for (String id : trustedFacets.getIds()) {
-					if (id.equals(facetId)) {
-						return true;
-					}
-				}
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * A double check about app signature that was passed by MainActivity as facetID.
-	 * @param facetId a string value composed by app hash. I.e. android:apk-key-hash:Lir5oIjf552K/XN4bTul0VS3GfM
-	 * @param context Application Context
-     * @return true if the signature executed on runtime matches if signature sent by MainActivity
-     */
-	public boolean checkAppSignature(String facetId, Context context){
-		try {
-			PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_SIGNATURES);
-			for (Signature sign: packageInfo.signatures) {
-				byte[] sB = sign.toByteArray();
-				MessageDigest messageDigest = MessageDigest.getInstance("SHA1");
-				messageDigest.update(sign.toByteArray());
-				String currentSignature = Base64.encodeToString(messageDigest.digest(), Base64.DEFAULT);
-				if (currentSignature.toLowerCase().contains(facetId.split(":")[2].toLowerCase())){
-					return true;
-				}
-			}
-		} catch (PackageManager.NameNotFoundException e) {
-			e.printStackTrace();
-		} catch (NoSuchAlgorithmException e) {
-			e.printStackTrace();
-		}
-		return false;
-	}
-
-	/**
-	 * Fetches the Trusted Facet List using the HTTP GET method. The location MUST be identified with
-	 * an HTTPS URL. A Trusted Facet List MAY contain an unlimited number of entries, but clients MAY
-	 * truncate or decline to process large responses.
-	 * @param appID an identifier for a set of different Facets of a relying party's application.
-	 *              The AppID is a URL pointing to the TrustedFacets, i.e. list of FacetIDs related
-	 *              to this AppID.
-	 * @return  Trusted Facets List
-     */
-	public String getTrustedFacets(String appID){
-		//TODO The caching related HTTP header fields in the HTTP response (e.g. “Expires”) SHOULD be respected when fetching a Trusted Facets List.
-		return Curl.getInSeparateThread(appID);
+		String serverResponse = getRegRequest(username);
+		return OpUtils.getUafRequest(serverResponse,facetId,context,false);
 	}
 
 	public String getRegRequest (String username){
@@ -195,22 +70,9 @@ public class Reg {
 	}
 	
 	public String clientSendRegResponse (String uafMessage){
-		StringBuffer res = new StringBuffer();
-		String decoded = null;
-		try {
-			JSONObject json = new JSONObject (uafMessage);
-			decoded = json.getString("uafProtocolMessage").replace("\\", "");
-		} catch (JSONException e) {
-			e.printStackTrace();
-		}
-		
-		res.append("#uafMessageegOut\n"+decoded);
-		String headerStr = "Content-Type:Application/json Accept:Application/json";
-		res.append("\n\n#ServerResponse\n");
-		String serverResponse = Curl.postInSeparateThread(Endpoints.getRegResponseEndpoint(), headerStr , decoded);
-		res.append(serverResponse);
+		String serverResponse = OpUtils.clientSendRegResponse(uafMessage,Endpoints.getRegResponseEndpoint());
 		saveAAIDandKeyID(serverResponse);
-		return res.toString();
+		return serverResponse;
 	}
 	
 	public String sendRegResponse (String regOut){


### PR DESCRIPTION
Although issue #5 pointed a problem in [Reg.class](https://github.com/eBay/UAF/blob/master/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Reg.java), the [Auth class](https://github.com/eBay/UAF/blob/master/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Auth.java) also has to [verify that the FacetID is authorized for the AppID](https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-protocol-v1.0-ps-20141208.html#authentication-request-processing-rules-for-fido-uaf-client) according to the algorithms in [FIDOAppIDAndFacets](https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-appid-and-facets-v1.0-ps-20141208.html). This pull request is a complement for pull request #14 . Duplicated code present in Reg class and in Auth class was moved to a new utility class.
