### PR TITLE
Fix to getTrustedFacets method to handle null or http(s) error answers.

### DIFF
--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/OpUtils.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/OpUtils.java
@@ -53,6 +53,9 @@ public abstract class OpUtils {
                     // Begin to fetch the Trusted Facet List using the HTTP GET method
                     String trustedFacetsJson = getTrustedFacets(appID);
                     TrustedFacetsList trustedFacets = (new Gson()).fromJson(trustedFacetsJson, TrustedFacetsList.class);
+                    if (trustedFacets.getTrustedFacets() == null){
+                        return getEmptyUafMsgRegRequest();
+                    }
                     // After processing the trustedFacets entry of the correct version and removing
                     // any invalid entries, if the caller's FacetID matches one listed in ids,
                     // the operation is allowed.


### PR DESCRIPTION
`getTrustedFacets(appID)` could return an error string (i.e. current https://www.head2toes.org uses an invalid security certificate, so http(s) returns an error string about SSL_ERROR_BAD_CERT_DOMAIN) instead of a `TrustedFacetsList` as expected. 
