### PR TITLE
If user tries to register without any local authentication setup on a…

### DIFF
--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/ExampleFidoUafActivity.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/ExampleFidoUafActivity.java
@@ -76,6 +76,16 @@ public class ExampleFidoUafActivity extends Activity {
 	    finish();
 	}
 
+	private void finishWithError(){
+		Bundle data = new Bundle();
+
+		data.putString("message", "Unable to complete local authentication, please setup android device authentication(pin, pattern, fingerprint..)");
+		Intent intent = new Intent();
+		intent.putExtras(data);
+		setResult(RESULT_CANCELED, intent);
+		finish();
+	}
+
 	private String processOp (String inUafOperationMsg){
 		String msg = "";
 		String inMsg = extract(inUafOperationMsg);
@@ -95,6 +105,8 @@ public class ExampleFidoUafActivity extends Activity {
 		Intent intent = keyguardManager.createConfirmDeviceCredentialIntent("UAF","Confirm Identity");
 		if (intent != null) {
 			startActivityForResult(intent, REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS);
+		} else {
+			finishWithError();
 		}
 
 	}


### PR DESCRIPTION
Added a small change to client app.
Currently if user has no lock setup on device, app does not show any message when user tries to register.
Added an error message to prompt user to setup the lock screen
