### PR TITLE
Fix base64url encoding

### DIFF
--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/AuthAssertionBuilder.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/AuthAssertionBuilder.java
@@ -16,8 +16,7 @@
 
 package org.ebayopensource.fido.uaf.client;
 
-import android.util.Base64;
-
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fidouafclient.util.Preferences;
 import org.ebayopensource.fido.uaf.crypto.Asn1;
 import org.ebayopensource.fido.uaf.crypto.BCrypt;
@@ -51,7 +50,7 @@ public class AuthAssertionBuilder {
 		byteout.write(encodeInt(length));
 		byteout.write(value);
 
-		String ret = Base64.encodeToString(byteout.toByteArray(), Base64.NO_PADDING);
+		String ret = Base64url.encodeToString(byteout.toByteArray());
 		logger.info(" : assertion : " + ret);
 		return ret;
 	}
@@ -144,14 +143,14 @@ public class AuthAssertionBuilder {
 //				.decodeBase64(TestData.TEST_PUB_KEY));
 		
 		PublicKey pub =
-				KeyCodec.getPubKey(Base64.decode(Preferences.getSettingsParam("pub"), Base64.URL_SAFE));
+				KeyCodec.getPubKey(Base64url.decode(Preferences.getSettingsParam("pub")));
 		PrivateKey priv =
-				KeyCodec.getPrivKey(Base64.decode(Preferences.getSettingsParam("priv"), Base64.URL_SAFE));
+				KeyCodec.getPrivKey(Base64url.decode(Preferences.getSettingsParam("priv")));
 //				KeyCodec.getPrivKey(Base64
 //				.decodeBase64(TestData.TEST_PRIV_KEY));
 
 		logger.info(" : dataForSigning : "
-				+ Base64.encode(dataForSigning, Base64.URL_SAFE));
+				+ Base64url.encode(dataForSigning));
 
 		BigInteger[] signatureGen = NamedCurve.signAndFromatToRS(priv,
 				SHA.sha(dataForSigning, "SHA-256"));
@@ -164,7 +163,7 @@ public class AuthAssertionBuilder {
 			throw new RuntimeException("Signatire match fail");
 		}
 		byte[] ret = Asn1.toRawSignatureBytes(signatureGen);
-		logger.info(" : signature : " + Base64.encode(ret, Base64.URL_SAFE));
+		logger.info(" : signature : " + Base64url.encode(ret));
 
 		return ret;
 	}

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/AuthenticationRequestProcessor.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/AuthenticationRequestProcessor.java
@@ -16,10 +16,9 @@
 
 package org.ebayopensource.fido.uaf.client;
 
-import android.util.Base64;
-
 import com.google.gson.Gson;
 
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fido.uaf.msg.AuthenticationRequest;
 import org.ebayopensource.fido.uaf.msg.AuthenticationResponse;
 import org.ebayopensource.fido.uaf.msg.AuthenticatorSignAssertion;
@@ -44,8 +43,8 @@ public class AuthenticationRequestProcessor {
 		fcParams.appID = request.header.appID;
 		fcParams.facetID = getFacetId();
 		fcParams.challenge = request.challenge;
-		response.fcParams = Base64.encodeToString(gson.toJson(
-				fcParams).getBytes(), Base64.URL_SAFE);
+		response.fcParams = Base64url.encodeToString(gson.toJson(
+				fcParams).getBytes());
 		setAssertions(response,builder);
 		return response;
 	}

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/RegAssertionBuilder.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/RegAssertionBuilder.java
@@ -16,8 +16,7 @@
 
 package org.ebayopensource.fido.uaf.client;
 
-import android.util.Base64;
-
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fidouafclient.util.Preferences;
 import org.ebayopensource.fido.uaf.crypto.Asn1;
 import org.ebayopensource.fido.uaf.crypto.BCrypt;
@@ -65,7 +64,7 @@ public class RegAssertionBuilder {
 		byteout.write(encodeInt(length));
 		byteout.write(value);
 
-		String ret = Base64.encodeToString(byteout.toByteArray(), Base64.URL_SAFE);
+		String ret = Base64url.encodeToString(byteout.toByteArray());
 		logger.info(" : assertion : " + ret);
 		Tags tags = parser.parse(ret);
 		String AAID = new String(tags.getTags().get(
@@ -108,7 +107,7 @@ public class RegAssertionBuilder {
 		byteout.write(value);
 		
 		byteout.write(encodeInt(TagsEnum.TAG_ATTESTATION_CERT.id));
-		value = Base64.decode(AttestCert.base64DERCert, Base64.URL_SAFE);
+		value = Base64url.decode(AttestCert.base64DERCert);
 		length = value.length;
 		byteout.write(encodeInt(length));
 		byteout.write(value);
@@ -177,17 +176,17 @@ public class RegAssertionBuilder {
 //				.encode(this.keyPair.getPrivate().getEncoded(),Base64.URL_SAFE));
 //		PublicKey pub = this.keyPair.getPublic();
 		PrivateKey priv =
-				KeyCodec.getPrivKey(Base64.decode(AttestCert.priv, Base64.URL_SAFE));
+				KeyCodec.getPrivKey(Base64url.decode(AttestCert.priv));
 				//this.keyPair.getPrivate();
 
 		logger.info(" : dataForSigning : "
-				+ Base64.encodeToString(dataForSigning, Base64.URL_SAFE));
+				+ Base64url.encodeToString(dataForSigning));
 
 		BigInteger[] signatureGen = NamedCurve.signAndFromatToRS(priv,
 				SHA.sha(dataForSigning, "SHA-256"));
 
 		boolean verify = NamedCurve.verify(
-				KeyCodec.getKeyAsRawBytes((ECPublicKey)KeyCodec.getPubKey(Base64.decode(AttestCert.pubCert, Base64.URL_SAFE))),
+				KeyCodec.getKeyAsRawBytes((ECPublicKey)KeyCodec.getPubKey(Base64url.decode(AttestCert.pubCert))),
 				//KeyCodec.getKeyAsRawBytes((ECPublicKey)this.keyPair.getPublic()),
 				SHA.sha(dataForSigning, "SHA-256"),
 				Asn1.decodeToBigIntegerArray(Asn1.getEncoded(signatureGen)));
@@ -195,15 +194,15 @@ public class RegAssertionBuilder {
 			throw new RuntimeException("Signatire match fail");
 		}
 		byte[] ret = Asn1.toRawSignatureBytes(signatureGen);
-		logger.info(" : signature : " + Base64.encodeToString(ret, Base64.URL_SAFE));
+		logger.info(" : signature : " + Base64url.encodeToString(ret));
 
 		return ret;
 	}
 
 	private byte[] getKeyId() throws IOException {
 		ByteArrayOutputStream byteout = new ByteArrayOutputStream();
-		String keyId = "ebay-test-key-"+ Base64.encodeToString(BCrypt.gensalt().getBytes(), Base64.NO_WRAP);
-		keyId = Base64.encodeToString(keyId.getBytes(), Base64.URL_SAFE);
+		String keyId = "ebay-test-key-"+ Base64url.encodeToString(BCrypt.gensalt().getBytes());
+		keyId = Base64url.encodeToString(keyId.getBytes());
 		Preferences.setSettingsParam("keyId", keyId);
 		byte[] value = keyId.getBytes();
 		byteout.write(value);

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/RegistrationRequestProcessor.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/RegistrationRequestProcessor.java
@@ -16,10 +16,9 @@
 
 package org.ebayopensource.fido.uaf.client;
 
-import android.util.Base64;
-
 import com.google.gson.Gson;
 
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fidouafclient.util.Preferences;
 import org.ebayopensource.fido.uaf.msg.AuthenticatorRegistrationAssertion;
 import org.ebayopensource.fido.uaf.msg.FinalChallengeParams;
@@ -50,8 +49,8 @@ public class RegistrationRequestProcessor {
 		Preferences.setSettingsParam("appID", fcParams.appID);
 		fcParams.facetID = getFacetId();
 		fcParams.challenge = regRequest.challenge;
-		response.fcParams = Base64.encodeToString(gson.toJson(
-				fcParams).getBytes(), Base64.URL_SAFE);
+		response.fcParams = Base64url.encodeToString(gson.toJson(
+				fcParams).getBytes());
 		setAssertions(response,builder);
 		return response;
 	}

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/op/Reg.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/client/op/Reg.java
@@ -16,10 +16,9 @@
 
 package org.ebayopensource.fido.uaf.client.op;
 
-import android.util.Base64;
-
 import com.google.gson.Gson;
 
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fidouafclient.util.Preferences;
 import org.ebayopensource.fido.uaf.client.RegistrationRequestProcessor;
 import org.ebayopensource.fido.uaf.crypto.KeyCodec;
@@ -49,8 +48,8 @@ public class Reg {
 		logger.info ("  [UAF][4]Reg - Reg Response Formed  ");
 		logger.info(regResponse.assertions[0].assertion);
 		logger.info ("  [UAF][6]Reg - done  ");
-		Preferences.setSettingsParam("pub", Base64.encodeToString(keyPair.getPublic().getEncoded(), Base64.URL_SAFE));
-		Preferences.setSettingsParam("priv", Base64.encodeToString(keyPair.getPrivate().getEncoded(), Base64.URL_SAFE));
+		Preferences.setSettingsParam("pub", Base64url.encodeToString(keyPair.getPublic().getEncoded()));
+		Preferences.setSettingsParam("priv", Base64url.encodeToString(keyPair.getPrivate().getEncoded()));
 		logger.info ("  [UAF][7]Reg - keys stored  ");
 		ret[0] = regResponse;
 		return getUafProtocolMsg( gson.toJson(ret) );

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/crypto/Base64url.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/crypto/Base64url.java
@@ -1,0 +1,39 @@
+package org.ebayopensource.fido.uaf.crypto;
+
+import android.util.Base64;
+
+/*
+ * Copyright 2016 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public final class Base64url {
+    private static final int BASE64URL_FLAGS = Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP;
+
+    public static String encodeToString(byte[] input) {
+        return Base64.encodeToString(input, BASE64URL_FLAGS);
+    }
+
+    public static byte[] encode(byte[] input) {
+        return Base64.encode(input, BASE64URL_FLAGS);
+    }
+
+    public static byte[] decode(String input) {
+        return Base64.decode(input, BASE64URL_FLAGS);
+    }
+
+    private Base64url() {
+
+    }
+}

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/tlv/TlvAssertionParser.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fido/uaf/tlv/TlvAssertionParser.java
@@ -16,7 +16,7 @@
 
 package org.ebayopensource.fido.uaf.tlv;
 
-import android.util.Base64;
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 
 import java.io.IOException;
 
@@ -24,8 +24,8 @@ import java.io.IOException;
 public class TlvAssertionParser {
 	
 	public Tags parse(String base64OfRegResponse) throws IOException {
-		ByteInputStream bytes = new ByteInputStream(Base64
-				.decode(base64OfRegResponse, Base64.URL_SAFE));
+		ByteInputStream bytes = new ByteInputStream(Base64url
+				.decode(base64OfRegResponse));
 		boolean isReg = false;
 		return parse (bytes, isReg);
 	}

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Auth.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Auth.java
@@ -16,6 +16,7 @@
 
 package org.ebayopensource.fidouafclient.op;
 
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fidouafclient.curl.Curl;
 import org.ebayopensource.fidouafclient.util.Endpoints;
 import org.ebayopensource.fidouafclient.util.Preferences;
@@ -31,7 +32,6 @@ import org.ebayopensource.fido.uaf.msg.asm.obj.AuthenticateIn;
 import org.json.JSONObject;
 
 import android.content.Context;
-import android.util.Base64;
 
 import com.google.gson.Gson;
 
@@ -92,8 +92,8 @@ public class Auth {
 		Preferences.setSettingsParam("appID", fcParams.appID);
 		fcParams.facetID = getFacetId();
 		fcParams.challenge = request.challenge;
-		return Base64.encodeToString(gson.toJson(
-				fcParams).getBytes(), Base64.URL_SAFE);
+		return Base64url.encodeToString(gson.toJson(
+				fcParams).getBytes());
 	}
 
 	private String getFacetId() {

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/OpUtils.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/OpUtils.java
@@ -9,6 +9,7 @@ import android.util.Base64;
 
 import com.google.gson.Gson;
 
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fido.uaf.msg.TrustedFacets;
 import org.ebayopensource.fido.uaf.msg.TrustedFacetsList;
 import org.ebayopensource.fido.uaf.msg.Version;
@@ -95,7 +96,7 @@ public abstract class OpUtils {
 
         try {
             trx.put("contentType", "text/plain");
-            trx.put("content", Base64.encodeToString("Authentication".getBytes(),Base64.URL_SAFE));
+            trx.put("content", Base64url.encodeToString("Authentication".getBytes()));
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Reg.java
+++ b/fidouafclient/app/src/main/java/org/ebayopensource/fidouafclient/op/Reg.java
@@ -16,6 +16,7 @@
 
 package org.ebayopensource.fidouafclient.op;
 
+import org.ebayopensource.fido.uaf.crypto.Base64url;
 import org.ebayopensource.fidouafclient.curl.Curl;
 import org.ebayopensource.fidouafclient.util.Endpoints;
 import org.ebayopensource.fidouafclient.util.Preferences;
@@ -30,7 +31,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import android.content.Context;
-import android.util.Base64;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -130,8 +130,8 @@ public class Reg {
 		fcParams.channelBinding.serverEndPoint = "";
 		fcParams.channelBinding.tlsServerCertificate = "";
 		fcParams.channelBinding.tlsUnique = "";
-		return Base64.encodeToString(gson.toJson(
-				fcParams).getBytes(), Base64.URL_SAFE);
+		return Base64url.encodeToString(gson.toJson(
+				fcParams).getBytes());
 	}
 
 	private String getFacetId() {


### PR DESCRIPTION
Fix base64url encoding on the Android client.

[FIDO UAF Protocol Specification v1.0 ](https://fidoalliance.org/specs/fido-uaf-v1.0-ps-20141208/fido-uaf-protocol-v1.0-ps-20141208.html) requires the following in "3. Protocol Details".

> The notation base64url(byte[8..64]) reads as 8-64 bytes of data encoded in base64url, "Base 64 Encoding with URL and Filename Safe Alphabet" [RFC4648] without padding.

And  [RFC4648](https://tools.ietf.org/html/rfc4648) requires the following in "3.1.  Line Feeds in Encoded Data".

> Implementations MUST NOT add line feeds to base-encoded data unless the specification referring to this document explicitly directs base encoders to add line feeds after a specific number of characters. 

Thus, the flags for android.util.Base64 are "Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP".  
